### PR TITLE
Fix waiting drain already being deleted with multiple writes to the same block

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,6 +276,8 @@ module.exports = function (filename, opts) {
         let drainsAfter = waitingDrain.get(blockIndex) || []
         if (drainsBefore.length == drainsAfter.length)
           waitingDrain.delete(blockIndex)
+        else if (drainsAfter.length === 0)
+          waitingDrain.delete(blockIndex)
         else
           waitingDrain.set(blockIndex, waitingDrain.get(blockIndex).slice(drainsBefore.length))
 


### PR DESCRIPTION
This should fix #15.

I think this can happen if you hit the write timeout. I'll try and see if I can get a test in to reproduce, but the fix should be simple enough. Would love an extra pair of eyes @staltz 