### PR TITLE
Refactor for loop to if

### DIFF
--- a/index.js
+++ b/index.js
@@ -293,8 +293,8 @@ module.exports = function (filename, opts) {
 
   function write() {
     // just one at a time
-    if (blockIndex = blocksToBeWritten.keys().next())
-      writeBlock(blockIndex.value)
+    if (blocksToBeWritten.size > 0)
+      writeBlock(blocksToBeWritten.keys().next().value)
   }
 
   function close(cb) {

--- a/index.js
+++ b/index.js
@@ -292,10 +292,9 @@ module.exports = function (filename, opts) {
   }
 
   function write() {
-    for (var blockIndex of blocksToBeWritten.keys()) {
-      writeBlock(blockIndex)
-      return // just one at a time
-    }
+    // just one at a time
+    if (blockIndex = blocksToBeWritten.keys().next())
+      writeBlock(blockIndex.value)
   }
 
   function close(cb) {


### PR DESCRIPTION
When reading through async-append-only-log trying to figure out the seeming lack of atomicity in its writes, I ran across this rather strangely-used `for` loop.  This refactors it into an `if` for clarity.  Seems to be about equivalent for performance, possibly slightly faster although by a fairly insignificant margin.