### PR TITLE
Safer writes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lodash.debounce": "^4.0.8",
     "looper": "^4.0.0",
     "ltgt": "^2.2.1",
+    "mutexify": "^1.3.1",
     "obz": "^1.0.2",
     "polyraf": "^1.1.0",
     "push-stream": "^11.0.0",


### PR DESCRIPTION
These 2 commits should make writes safer in general.

- Fsync: this is similar to what we use in [atomic-file-rw](https://github.com/ssb-ngi-pointer/atomic-file-rw/blob/379458da1d988b75038e2e93acd689a7df3b0935/fs.js#L34)
- Locking: also a technique also used in [atomic-file-rw](https://github.com/ssb-ngi-pointer/atomic-file-rw/blob/379458da1d988b75038e2e93acd689a7df3b0935/fs.js#L24)

It is worth mentioning that the locking actually fixes a potential (rare) problem. The following could happen: 
 - we schedule a write for block 100 which is not full
 - The scheduled write happens, while it is writing (async operation) we add something more to the block 100
 - Before it finishes the write, the second write is scheduled to run, which leads to 2 concurrent writes to the same part of the file, which is according to the fs documentation not safe

While I havn't been able to reproduce the problem in https://github.com/ssb-ngi-pointer/jitdb/issues/173 I believe these changes should be safer in general. To sum up the problem: we somehow end up with corrupted blocks on disc. So when we read them again we crash. We put into an "auto healer" in https://github.com/ssb-ngi-pointer/async-append-only-log/pull/12, but we should rather fix these issues as best as we can. My hunch is that the issues happens when the app is closed before it properly writes data (fsync tries to make this more likely) or the potentiel issue that locking should fix.