### PR TITLE
Transaction support

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -78,8 +78,47 @@ tape('basic json re-read', function (t) {
         if(err) throw err
         t.deepEqual(b2, json2)
 
-        t.end()
+        db.close(t.end)
       })
     })
+  })
+})
+
+tape('basic transaction', function (t) {
+  var file = '/tmp/dsf-test-basic-transaction-json.log'
+  try { fs.unlinkSync(file) } catch (_) {}
+  var db = Log(file, {
+    blockSize: 2*1024,
+    codec: require('flumecodec/json')
+  })
+
+  db.appendTransaction([json1, json2], function (err, offsets) {
+    if(err) throw err
+    t.equal(offsets[0], 0)
+    db.get(offsets[0], function (err, b) {
+      if(err) throw err
+      t.deepEqual(b, json1)
+
+      db.get(offsets[1], function (err, b2) {
+        if(err) throw err
+        t.deepEqual(b2, json2)
+
+        db.close(t.end)
+      })
+    })
+  })
+})
+
+tape('transaction fail', function (t) {
+  var file = '/tmp/dsf-test-transaction-tail-json.log'
+  try { fs.unlinkSync(file) } catch (_) {}
+  var db = Log(file, {
+    blockSize: 25,
+    codec: require('flumecodec/json')
+  })
+
+  db.appendTransaction([json1, json2], function (err, offsets) {
+    t.equal(err.message, 'data larger than block size', 'fails on too much data')
+    db.close(t.end)
   })
 })


### PR DESCRIPTION
This adds the ability to make sure that several pieces of data are written to disc at the same time. We need this support for indexed replication in EBT where you will receive both the index + the indexed message at the same time and need to make sure that we write the messages to disc in one go so that local db2 indexes will see the messages at the same time and also that EBT can expect that if it sees an index that the indexed message will be there. Lastly if it crashes in the middle, that we can use the index to know that we for sure will also have the indexed message stored. Basically we need to add things in what amounts to a transaction :-)