### PR TITLE
fix stream.resume() to be idempotent

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -149,7 +149,7 @@ Stream.prototype._resumeCallback = function (err, block) {
     this._next()
   }
   else if (handled === null) {
-    this.writing = false
+    if (!this.live) this.writing = false
     return
   }
   else if (this.live !== true) this.abort()

--- a/stream.js
+++ b/stream.js
@@ -114,7 +114,7 @@ Stream.prototype._handleBlock = function(block) {
 
 Stream.prototype._resume = function () {
   if (!this.sink || this.sink.paused) {
-    this.writing = false
+    if (!this.live) this.writing = false
     return
   }
 

--- a/stream.js
+++ b/stream.js
@@ -113,7 +113,10 @@ Stream.prototype._handleBlock = function(block) {
 }
 
 Stream.prototype._resume = function () {
-  if (!this.sink || this.sink.paused) return
+  if (!this.sink || this.sink.paused) {
+    this.writing = false
+    return
+  }
 
   if (this.ended) {
     if (!this.sink.ended) {
@@ -145,11 +148,15 @@ Stream.prototype._resumeCallback = function (err, block) {
     this.cursor = this.blocks.getNextBlockIndex(this.cursor)
     this._next()
   }
-  else if (handled === null) return
+  else if (handled === null) {
+    this.writing = false
+    return
+  }
   else if (this.live !== true) this.abort()
 }
 
 Stream.prototype.resume = function () {
+  if (!this.live && this.writing) return
   this._next = looper(this._resume.bind(this))
   this._next()
 }

--- a/test/idempotent-resume.js
+++ b/test/idempotent-resume.js
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2021 Anders Rune Jensen
+//
+// SPDX-License-Identifier: Unlicense
+
+var tape = require('tape')
+var fs = require('fs')
+var Log = require('../')
+
+const filename = '/tmp/dsf-idempotent-resume.log'
+
+try {
+  fs.unlinkSync(filename)
+} catch (_) {}
+var log = Log(filename, {blockSize: 64 * 1024})
+
+function B(fill, length) {
+  var b = Buffer.alloc(length)
+  b.fill(fill)
+  return b
+}
+
+const TOTAL_RECORDS = 300_000
+const getRecordLength = (i) => 1 + (i % 500)
+
+tape('populate', function (t) {
+  const records = Array(TOTAL_RECORDS)
+    .fill(null)
+    .map((x, i) => B(0x10, getRecordLength(i)))
+  log.append(records, () => {
+    log.onDrain(() => {
+      t.end()
+    })
+  })
+})
+
+tape('a second resume() on the same stream is idempotent', function (t) {
+  const stream = log.stream({offsets: false})
+
+  // The pipe causes the 1st resume to happen
+  let i = 0
+  stream.pipe({
+    paused: false,
+    offsets: false,
+    write(buf) {
+      const expected = getRecordLength(i)
+      const actual = buf.length
+      if (actual !== expected) {
+        t.fail(`${i}-th record has ${actual} bytes, expected ${expected}`)
+        process.exit(1) // otherwise the test will keep spamming many `t.fail`
+      }
+      i += 1
+    },
+    end() {
+      t.equals(i, TOTAL_RECORDS)
+      t.end()
+    },
+  })
+
+  // This is the 2nd resume
+  stream.resume()
+})
+
+tape('close', function (t) {
+  t.equal(log.streams.length, 0, 'no open streams')
+  log.close(() => {
+    t.end()
+  })
+})


### PR DESCRIPTION
Full context for this PR is given at the comment https://github.com/ssb-ngi-pointer/ssb-db2/issues/302#issuecomment-1015534847. This PR is fundamental to fix several database glitches experienced by users of ssb-db2.

1st :x:, 2nd :heavy_check_mark: 