### PR TITLE
Add test for ending up in wrong skip_next state on empty db

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -139,13 +139,13 @@ Stream.prototype._resume = function () {
     return
   }
 
+  if (this.state === STREAM_STATE.INITIALIZING)
+    return // not ready yet
+
   if (!this.sink || this.sink.paused) {
     this.state = STREAM_STATE.PAUSED
     return
   }
-
-  if (this.state === STREAM_STATE.INITIALIZING)
-    return // not ready yet
 
   this.state = STREAM_STATE.RUNNING
 


### PR DESCRIPTION
First test should reproduce the bug seen in [replication scheduler](https://github.com/ssb-ngi-pointer/ssb-replication-scheduler/pull/5#issuecomment-1043197983)

The problem was that it was possible to set skip_next on an empty database so that the first value is actually skipped and never returned to the indexes.