### PR TITLE
improve del() performance by 2x

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,8 +201,7 @@ module.exports = function (filename, opts) {
 
       const recordOffset = getRecordOffset(offset)
       const recordLength = buffer.readUInt16LE(recordOffset)
-      const nullBytes = Buffer.alloc(recordLength)
-      nullBytes.copy(buffer, recordOffset + 2)
+      buffer.fill(0, recordOffset + 2, recordOffset + 2 + recordLength)
 
       // we write directly here to make normal write simpler
       writeWithFSync(offset - recordOffset, buffer, null, cb)


### PR DESCRIPTION
Something I stumbled upon while working on compaction, is that we should use `Buffer.fill()` instead of allocating a new buffer and copying over. But also it's good to discover this now, before we start making extensive usage of del().

Use this script in Node.js to verify the numbers yourself:

```js
const TOTAL_SIZE = 100e6 // 100 MB
const FILL_SIZE = 10
const TIMES = TOTAL_SIZE / FILL_SIZE
const buf1 = Buffer.allocUnsafe(TOTAL_SIZE)
const buf2 = Buffer.allocUnsafe(TOTAL_SIZE)

console.time('copy')
for (let i = 0; i < TIMES; i++) {
  const start = FILL_SIZE * i
  const end = FILL_SIZE * (i + 1)
  Buffer.alloc(FILL_SIZE).copy(buf1, start)
}
console.timeEnd('copy')

console.time('fill')
for (let i = 0; i < TIMES; i++) {
  const start = FILL_SIZE * i
  const end = FILL_SIZE * (i + 1)
  buf2.fill(0, start, end)
}
console.timeEnd('fill')
```

I get:

```
copy: 979.516ms
fill: 492.705ms
```