### PR TITLE
move record byte math to its own file

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ module.exports = function (filename, opts) {
 
           latestBlockBuf = blockBuf
           latestBlockIndex = fileSize / blockSize - 1
-          const recSize = Record.size(blockBuf, offsetInBlock)
+          const recSize = Record.readSize(blockBuf, offsetInBlock)
           nextOffsetInBlock = offsetInBlock + recSize
           since.set(blockStart + offsetInBlock)
 

--- a/index.js
+++ b/index.js
@@ -58,8 +58,8 @@ module.exports = function (filename, opts) {
       latestBlockBuf = Buffer.alloc(blockSize)
       latestBlockIndex = 0
       nextOffsetInBlock = 0
-      since.set(-1)
       cache.set(0, latestBlockBuf)
+      since.set(-1)
       while (waiting.length) waiting.shift()()
     } else {
       const blockStart = fileSize - blockSize
@@ -241,9 +241,9 @@ module.exports = function (filename, opts) {
       blockBuf: latestBlockBuf,
       offset,
     })
+    nextOffsetInBlock += Record.size(encodedData)
     scheduleWrite()
     debug('data inserted at offset %d', offset)
-    nextOffsetInBlock += Record.size(encodedData)
     return offset
   }
 
@@ -295,8 +295,8 @@ module.exports = function (filename, opts) {
         blockBuf: latestBlockBuf,
         offset,
       })
-      debug('data inserted at offset %d', offset)
       nextOffsetInBlock += Record.size(encodedData)
+      debug('data inserted at offset %d', offset)
     }
 
     scheduleWrite()

--- a/record.js
+++ b/record.js
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2022 Anders Rune Jensen
+//
+// SPDX-License-Identifier: LGPL-3.0-only
+
+/*
+Binary format for a Record:
+
+<record>
+  <dataLength: UInt16LE>
+  <dataBuf: Arbitrary Bytes>
+</record>
+
+The "Header" is the first two bytes for the dataLength.
+*/
+
+const HEADER_SIZE = 2 // uint16
+
+function size(dataBuf) {
+  return HEADER_SIZE + dataBuf.length
+}
+
+function readDataLength(blockBuf, offsetInBlock) {
+  return blockBuf.readUInt16LE(offsetInBlock)
+}
+
+function readSize(blockBuf, offsetInBlock) {
+  const dataLength = readDataLength(blockBuf, offsetInBlock)
+  return HEADER_SIZE + dataLength
+}
+
+function read(blockBuf, offsetInBlock) {
+  const dataLength = readDataLength(blockBuf, offsetInBlock)
+  const dataStart = offsetInBlock + HEADER_SIZE
+  const dataBuf = blockBuf.slice(dataStart, dataStart + dataLength)
+  const size = HEADER_SIZE + dataLength
+  return [dataBuf, size]
+}
+
+function write(blockBuf, offsetInBlock, dataBuf) {
+  blockBuf.writeUInt16LE(dataBuf.length, offsetInBlock) // write dataLength
+  dataBuf.copy(blockBuf, offsetInBlock + HEADER_SIZE) // write dataBuf
+}
+
+function overwriteWithZeroes(blockBuf, offsetInBlock) {
+  const dataLength = readDataLength(blockBuf, offsetInBlock)
+  const dataStart = offsetInBlock + HEADER_SIZE
+  const dataEnd = dataStart + dataLength
+  blockBuf.fill(0, dataStart, dataEnd)
+}
+
+module.exports = {
+  HEADER_SIZE,
+  size,
+  readDataLength,
+  readSize,
+  read,
+  write,
+  overwriteWithZeroes,
+}


### PR DESCRIPTION
This is my last PR for today. 

My motivation is that I was stumbling upon all these `+ 2` in the offset math, and felt that this stuff is easy to get wrong, so I moved all of that logic to its own file, `./record.js` which is the only place that knows about `uint16`. This makes it easier in the future, in case we want to upgrade to `uint32` (or whatever), we only have a small file to update. The goal was to separate the "internals of a record" from the overall logic of a "block".

Additional stuff: 

- made end-of-block logic more explicit
- Some reordering of lines to maintain consistency
- Changing a `array.forEach` to `for (const x of array)` because it's better for stack traces