### PR TITLE
rename getNextBlockIndex

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,12 +91,12 @@ module.exports = function (filename, opts) {
     return offset - getOffsetInBlock(offset)
   }
 
-  function getBlockIndex(offset) {
-    return getBlockStart(offset) / blockSize
+  function getNextBlockStart(offset) {
+    return getBlockStart(offset) + blockSize
   }
 
-  function getNextBlockIndex(offset) {
-    return (getBlockIndex(offset) + 1) * blockSize
+  function getBlockIndex(offset) {
+    return getBlockStart(offset) / blockSize
   }
 
   const writeLock = mutexify()
@@ -198,7 +198,7 @@ module.exports = function (filename, opts) {
 
     let nextOffset
     if (nextLength === EOB.asNumber) {
-      if (getNextBlockIndex(offset) > since.value) nextOffset = -1
+      if (getNextBlockStart(offset) > since.value) nextOffset = -1
       else nextOffset = 0
     } else {
       nextOffset = offset + recSize
@@ -421,7 +421,7 @@ module.exports = function (filename, opts) {
     filename,
     // Internals needed for ./stream.js:
     onReady,
-    getNextBlockIndex,
+    getNextBlockStart,
     getDataNextOffset,
     getBlock,
     streams: [],

--- a/stream.js
+++ b/stream.js
@@ -144,7 +144,7 @@ Stream.prototype._resumeCallback = function _resumeCallback(err, block) {
 
   const blockState = this._handleBlock(block)
   if (blockState === BLOCK_STATE.GET_NEXT_BLOCK) {
-    this.cursor = this.log.getNextBlockIndex(this.cursor)
+    this.cursor = this.log.getNextBlockStart(this.cursor)
     this._next()
   } else if (blockState === BLOCK_STATE.PAUSED) {
     this.state = STREAM_STATE.PAUSED


### PR DESCRIPTION
I just realized that `getNextBlockIndex()` doesn't actually return an index! It returns the file offset where the block starts. And since that's what it actually does, I found a simpler way of implementing it.