### PR TITLE
Compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,45 @@ log.since((offset) => {
 })
 ```
 
+### Compact the log (remove deleted records)
+
+```js
+log.compact((err) => {
+  // This callback will be called once, when the compaction is done.
+})
+```
+
+### Track progress of compactions
+
+As an [obz] observable:
+
+```js
+log.compactionProgress((progress) => {
+  console.log(progress)
+  // {
+  //   startOffset,
+  //   compactedOffset,
+  //   unshiftedOffset,
+  //   percent,
+  //   done,
+  //   sizeDiff,
+  // }
+})
+```
+
+Where
+
+- `startOffset`: the starting point for compaction. All offsets smaller than
+  this have been left untouched by the compaction algorithm.
+- `compactedOffset`: all records up until this point have been compacted so far.
+- `unshiftedOffset`: offset for the first record that hasn't yet been "moved"
+  to previous slots. Tracking this allows you to see the algorithm proceeding.
+- `percent`: a number between 0 and 1 to indicate the progress of compaction.
+- `done`: a boolean indicating whether compaction is ongoing (`false`) or done
+  (`true`).
+- `sizeDiff`: number of bytes freed after compaction is finished. Only available
+  if `done` is `true`.
+
 ### Close the log
 
 ```js

--- a/compaction.js
+++ b/compaction.js
@@ -108,8 +108,7 @@ class PersistentState {
  * - Once all blocks have been compacted, delete the state file
  */
 class Compaction {
-  constructor(log, lastBlockIndex, opts, onDone) {
-    // TODO opts?
+  constructor(log, lastBlockIndex, onDone) {
     this.log = log
     this.persistentState = new PersistentState(log.filename, log.blockSize)
     this.onDone = onDone

--- a/compaction.js
+++ b/compaction.js
@@ -1,0 +1,154 @@
+const Record = require('./record')
+
+module.exports = class Compaction {
+  constructor(log, lastBlockIndex, opts, onDone) {
+    // TODO opts?
+    this.log = log
+    this.onDone = onDone
+    this.LAST_BLOCK_INDEX = lastBlockIndex
+
+    this.uncompactedBlockIndex = -1
+    this.uncompactedBlockBuf = null
+    this.uncompactedOffset = 0
+
+    this.compactedBlockBuf = null
+    this.compactedOffset = 0
+
+    this.unshiftedBlockIndex = 0
+    this.unshiftedBlockBuf = 0
+    this.unshiftedOffset = 0
+
+    this.compactNextBlock()
+  }
+
+  continueCompactingBlock() {
+    while (true) {
+      const blockStart = this.uncompactedBlockIndex * this.log.blockSize
+      const offsetInBlock = this.uncompactedOffset - blockStart
+      const [nextOffset, dataBuf] = this.log.getDataNextOffset(
+        this.uncompactedBlockBuf,
+        this.uncompactedOffset
+      )
+
+      if (dataBuf === null) {
+        if (!this.unshiftedBlockBuf) {
+          this.getNextUnshiftedBlock(() => {
+            this.continueCompactingBlock()
+          })
+          return
+        }
+        // All records have been shifted, end of log reached
+        if (this.unshiftedBlockIndex === -1) {
+          // FIXME: finalize ongoing writes before actually stopping
+          this.stop(this.uncompactedBlockIndex)
+          return
+        }
+
+        const unshiftedDataBuf = this.getNextUnshifted()
+        if (unshiftedDataBuf === null) continue
+        Record.write(this.compactedBlockBuf, offsetInBlock, unshiftedDataBuf)
+        this.uncompactedOffset = nextOffset
+      } else {
+        Record.write(this.compactedBlockBuf, offsetInBlock, dataBuf)
+        this.uncompactedOffset = nextOffset
+      }
+
+      if (nextOffset === 0) {
+        this.log.overwrite(this.uncompactedBlockIndex, this.compactedBlockBuf)
+        setImmediate(() => this.compactNextBlock())
+        return
+      }
+
+      if (nextOffset === -1) {
+        // FIXME: unless I'm missing something, this should never happen,
+        // because the last block will not be compacted since it's still
+        // work-in-progress (see the bail out in compactNextBlock())
+        throw new Error('this should be unreachable')
+      }
+    }
+  }
+
+  getNextUnshiftedBlock(cb) {
+    const nextBlockIndex = this.unshiftedBlockIndex + 1
+    const nextBlockStart = nextBlockIndex * this.log.blockSize
+    this.log.getBlock(nextBlockStart, (err, blockBuf) => {
+      if (err) return this.onDone(err)
+      this.unshiftedBlockIndex = nextBlockIndex
+      this.unshiftedBlockBuf = blockBuf
+      this.unshiftedOffset = nextBlockStart
+      cb()
+    })
+  }
+
+  getNextUnshifted() {
+    while (true) {
+      const [nextOffset, dataBuf] = this.log.getDataNextOffset(
+        this.unshiftedBlockBuf,
+        this.unshiftedOffset
+      )
+
+      if (dataBuf === null) {
+        if (nextOffset === -1) {
+          this.unshiftedBlockIndex = -1
+          return null
+        } else if (nextOffset === 0) {
+          this.unshiftedBlockBuf = null
+          return null
+        } else {
+          this.unshiftedOffset = nextOffset
+          continue
+        }
+      } else {
+        if (nextOffset === -1) {
+          this.unshiftedBlockIndex = -1
+          return dataBuf
+        } else if (nextOffset === 0) {
+          this.unshiftedBlockBuf = null
+          return dataBuf
+        } else {
+          this.unshiftedOffset = nextOffset
+          return dataBuf
+        }
+      }
+    }
+  }
+
+  compactNextBlock() {
+    const lastCompactedBlockIndex = this.uncompactedBlockIndex
+    this.uncompactedBlockIndex += 1
+
+    if (this.uncompactedBlockIndex === this.LAST_BLOCK_INDEX) {
+      if (this.unshiftedBlockIndex === -1) {
+        this.stop(lastCompactedBlockIndex)
+      } else {
+        this.stop(this.LAST_BLOCK_INDEX)
+      }
+      return
+    }
+
+    const blockStart = this.uncompactedBlockIndex * this.log.blockSize
+    this.log.getBlock(blockStart, (err, blockBuf) => {
+      if (err) return this.onDone(err)
+      this.uncompactedBlockBuf = blockBuf
+      this.uncompactedOffset = blockStart
+      this.compactedBlockBuf = Buffer.alloc(this.log.blockSize)
+      this.compactedOffset = blockStart
+      if (this.unshiftedBlockIndex === this.uncompactedBlockIndex) {
+        this.unshiftedBlockBuf = this.uncompactedBlockBuf
+      }
+      this.continueCompactingBlock()
+    })
+  }
+
+  stop(lastBlockIndex) {
+    this.uncompactedBlockIndex = -1
+    this.uncompactedBlockBuf = null
+    this.uncompactedOffset = -1
+    this.compactedBlockBuf = null
+    this.compactedOffset = -1
+    this.unshiftedBlockIndex = -1
+    this.unshiftedBlockBuf = null
+    this.unshiftedOffset = -1
+    this.onDone(null, lastBlockIndex)
+  }
+}

--- a/compaction.js
+++ b/compaction.js
@@ -17,7 +17,7 @@ function getStateFilename(logFilename) {
  *
  * - bytes 0..3: UInt32LE for the blockIndex to-be-compacted
  * - bytes 4..7: UInt32LE for the 1st unshifted record's offset
- * - bytes 8..(8+blockSize): blockBuf containing the 1st unshifted record
+ * - bytes 8..(8+blockSize-1): blockBuf containing the 1st unshifted record
  */
 function PersistentState(logFilename, blockSize) {
   const raf = RAF(getStateFilename(logFilename))

--- a/compaction.js
+++ b/compaction.js
@@ -174,6 +174,6 @@ module.exports = class Compaction {
     this.unshiftedBlockIndex = -1
     this.unshiftedBlockBuf = null
     this.unshiftedOffset = -1
-    this.onDone(null, lastBlockIndex)
+    this.log.truncate(lastBlockIndex, this.onDone)
   }
 }

--- a/compaction.js
+++ b/compaction.js
@@ -192,6 +192,7 @@ function Compaction(log, onDone) {
       findNonDeletedOffsetGTE(blockStart, function gotNonDeleted(err, offset) {
         if (err) return cb(err)
         if (offset === -1) {
+          compactedBlockIndex = Math.floor((holeOffset - 1) / log.blockSize)
           stop()
           return
         }

--- a/compaction.js
+++ b/compaction.js
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-only
 
-const debug = require('debug')('async-flumelog')
+const debug = require('debug')('async-append-only-log')
 const Record = require('./record')
 
 module.exports = class Compaction {

--- a/compaction.js
+++ b/compaction.js
@@ -149,7 +149,6 @@ function Compaction(log, onDone) {
           unshiftedBlockIndex = Math.floor(
             state.unshiftedOffset / log.blockSize
           )
-          compactedOffset = state.compactedBlockIndex * log.blockSize
           savePersistentState(cb)
         })
       } else {

--- a/compaction.js
+++ b/compaction.js
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-only
 
+const debug = require('debug')('async-flumelog')
 const Record = require('./record')
 
 module.exports = class Compaction {
@@ -65,7 +66,11 @@ module.exports = class Compaction {
 
       if (nextOffset === 0) {
         if (this.uncompactedBlockHasHoles) {
-          this.log.overwrite(this.uncompactedBlockIndex, this.compactedBlockBuf)
+          const blockIndex = this.uncompactedBlockIndex
+          this.log.overwrite(blockIndex, this.compactedBlockBuf, (err) => {
+            if (err) throw err
+            debug('compacted block %d', blockIndex)
+          })
         }
         setImmediate(() => this.compactNextBlock())
         return

--- a/compaction.js
+++ b/compaction.js
@@ -37,7 +37,7 @@ module.exports = class Compaction {
       if (this.unshiftedBlockIndex === -1) {
         this.saveCompactedBlock((err) => {
           if (err) throw err
-          this.stop(this.compactedBlockIndex)
+          this.stop()
         })
         return
       }
@@ -126,16 +126,7 @@ module.exports = class Compaction {
   }
 
   compactNextBlock() {
-    const lastCompactedBlockIndex = this.compactedBlockIndex
     this.compactedBlockIndex += 1
-
-    if (
-      this.compactedBlockIndex > this.LAST_BLOCK_INDEX ||
-      this.unshiftedBlockIndex === -1
-    ) {
-      this.stop(lastCompactedBlockIndex)
-      return
-    }
 
     const blockStart = this.compactedBlockIndex * this.log.blockSize
     this.compactedBlockBuf = Buffer.alloc(this.log.blockSize)
@@ -144,9 +135,9 @@ module.exports = class Compaction {
     this.continueCompactingBlock()
   }
 
-  stop(lastBlockIndex) {
+  stop() {
     this.compactedBlockBuf = null
     this.unshiftedBlockBuf = null
-    this.log.truncate(lastBlockIndex, this.onDone)
+    this.log.truncate(this.compactedBlockIndex, this.onDone)
   }
 }

--- a/compaction.js
+++ b/compaction.js
@@ -183,6 +183,7 @@ function Compaction(log, onDone) {
     findFirstDeletedOffset(function gotFirstDeleted(err, holeOffset) {
       if (err) return cb(err)
       if (holeOffset === -1) {
+        compactedBlockIndex = Math.floor(log.since.value / log.blockSize)
         stop()
         return
       }

--- a/compaction.js
+++ b/compaction.js
@@ -47,7 +47,7 @@ class PersistentState {
           if (err) return cb(err)
           const state = {
             compactedBlockIndex: buf.readUInt16LE(0),
-            unshiftedOffset: buf.readUInt16LE(2) - 1,
+            unshiftedOffset: buf.readUInt16LE(2),
             unshiftedBlockBuf: buf.slice(4),
             initial: false,
           }
@@ -60,7 +60,7 @@ class PersistentState {
   save(state, cb) {
     const buf = Buffer.alloc(4)
     buf.writeUInt16LE(state.compactedBlockIndex, 0)
-    buf.writeUInt16LE(state.unshiftedOffset + 1, 2) // FIXME: could offset be -1?
+    buf.writeUInt16LE(state.unshiftedOffset, 2)
     state.unshiftedBlockBuf.copy(buf, 4)
     this.writeLock((unlock) => {
       this.raf.write(0, buf, (err) => {

--- a/compaction.js
+++ b/compaction.js
@@ -36,7 +36,7 @@ module.exports = class Compaction {
       // When all records have been shifted (thus end of log), stop compacting
       if (this.unshiftedBlockIndex === -1) {
         this.saveCompactedBlock((err) => {
-          if (err) throw err
+          if (err) return this.onDone(err)
           this.stop()
         })
         return
@@ -81,7 +81,7 @@ module.exports = class Compaction {
       const blockIndex = this.compactedBlockIndex
       this.log.overwrite(blockIndex, this.compactedBlockBuf, (err) => {
         if (err && cb) cb(err)
-        else if (err) throw err
+        else if (err) return this.onDone(err)
         else {
           debug('compacted block %d', blockIndex)
           if (cb) cb()

--- a/compaction.js
+++ b/compaction.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 Anders Rune Jensen
+//
+// SPDX-License-Identifier: LGPL-3.0-only
+
 const Record = require('./record')
 
 module.exports = class Compaction {

--- a/compaction.js
+++ b/compaction.js
@@ -4,6 +4,7 @@
 
 const RAF = require('polyraf')
 const fs = require('fs')
+const Obv = require('obz')
 const push = require('push-stream')
 const mutexify = require('mutexify')
 const debug = require('debug')('async-append-only-log')
@@ -117,6 +118,7 @@ function PersistentState(logFilename, blockSize) {
  */
 function Compaction(log, onDone) {
   const persistentState = PersistentState(log.filename, log.blockSize)
+  const since = Obv() // for the unshifted offset
 
   let compactedBlockIndex = -1
   let compactedBlockBuf = null
@@ -339,6 +341,7 @@ function Compaction(log, onDone) {
   }
 
   function compactNextBlock() {
+    since.set(unshiftedOffset)
     compactedBlockIndex += 1
     compactedBlockBuf = Buffer.alloc(log.blockSize)
     compactedOffset = compactedBlockIndex * log.blockSize
@@ -358,7 +361,9 @@ function Compaction(log, onDone) {
     })
   }
 
-  return {}
+  return {
+    since,
+  }
 }
 
 Compaction.stateFileExists = stateFileExists

--- a/errors.js
+++ b/errors.js
@@ -34,10 +34,30 @@ function deletedRecordErr() {
   return new ErrorWithCode('Record has been deleted', 'ERR_AAOL_DELETED_RECORD')
 }
 
+function delDuringCompactErr() {
+  return new Error('Cannot delete while compaction is in progress')
+}
+
+function appendLargerThanBlockErr() {
+  return new Error('Data to be appended is larger than block size')
+}
+
+function streamClosedErr() {
+  return new Error('async-append-only-log stream is closed')
+}
+
+function appendTransactionWantsArrayErr() {
+  return new Error('appendTransaction expects first argument to be an array')
+}
+
 module.exports = {
   ErrorWithCode,
   nanOffsetErr,
   negativeOffsetErr,
   outOfBoundsOffsetErr,
   deletedRecordErr,
+  delDuringCompactErr,
+  appendLargerThanBlockErr,
+  streamClosedErr,
+  appendTransactionWantsArrayErr,
 }

--- a/index.js
+++ b/index.js
@@ -429,7 +429,7 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
       waitingCompaction.push(cb)
       return
     }
-    compaction = new Compaction(self, latestBlockIndex, (err) => {
+    compaction = new Compaction(self, (err) => {
       compaction = null
       if (err) return cb(err)
       while (waitingCompaction.length) waitingCompaction.shift()()

--- a/index.js
+++ b/index.js
@@ -414,7 +414,7 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
     for (let i = lastBlockIndex + 1; i < latestBlockIndex; ++i) {
       cache.remove(i)
     }
-    truncateWithFSync(newSize, (err) => {
+    truncateWithFSync(newSize, function onTruncateWithFSyncDone(err) {
       if (err) return cb(err)
       latestBlockIndex = lastBlockIndex
       since.set(newSize) // FIXME: smells wrong

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
 
   onLoad(function maybeResumeCompaction() {
     if (Compaction.stateFileExists(filename)) {
-      compact({}, function onCompactDone(err) {
+      compact(function onCompactDone(err) {
         if (err) throw err
       })
     }
@@ -423,12 +423,12 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
     })
   }
 
-  function compact(opts, cb) {
+  function compact(cb) {
     if (compaction) {
       debug('compaction already in progress')
       return
     }
-    compaction = new Compaction(self, latestBlockIndex, opts, (err) => {
+    compaction = new Compaction(self, latestBlockIndex, (err) => {
       compaction = null
       if (err) return cb(err)
       while (waitingCompaction.length) waitingCompaction.shift()()

--- a/index.js
+++ b/index.js
@@ -428,11 +428,13 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
       waitingCompaction.push(cb)
       return
     }
-    compaction = new Compaction(self, (err) => {
-      compaction = null
-      if (err) return cb(err)
-      while (waitingCompaction.length) waitingCompaction.shift()()
-      cb()
+    onDrain(function startCompactAfterDrain() {
+      compaction = new Compaction(self, (err) => {
+        compaction = null
+        if (err) return cb(err)
+        while (waitingCompaction.length) waitingCompaction.shift()()
+        cb()
+      })
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -378,13 +378,10 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
     })
   }
 
-  function overwrite(blockIndex, blockBuf) {
+  function overwrite(blockIndex, blockBuf, cb) {
     cache.set(blockIndex, blockBuf)
     const blockStart = blockIndex * blockSize
-    debug('overwriting block at %d', blockStart)
-    writeWithFSync(blockStart, blockBuf, null, (err) => {
-      if (err) throw err
-    })
+    writeWithFSync(blockStart, blockBuf, null, cb)
   }
 
   function compact(opts, cb) {

--- a/index.js
+++ b/index.js
@@ -80,7 +80,6 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
       since.set(-1)
       while (waitingLoad.length) waitingLoad.shift()()
     } else {
-      // FIXME: load FUB and if it's >=0, then continue compaction
       const blockStart = fileSize - blockSize
       raf.read(blockStart, blockSize, function lastBlockLoaded(err, blockBuf) {
         if (err) throw err
@@ -457,7 +456,6 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
       waitingCompaction.push(fn)
       return
     }
-    // FIXME: needs to be aware of compaction, and wait for it
     if (blocksToBeWritten.size === 0 && writingBlockIndex === -1) fn()
     else {
       const latestBlockIndex =
@@ -475,9 +473,6 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
     for (let x of iterable) res = x
     return res
   }
-
-  // FIXME: stream() to find firstUncompactedBlockIndex has to be different from
-  // normal stream() (which itself should start from FUBI)
 
   return (self = {
     // Public API:

--- a/index.js
+++ b/index.js
@@ -426,6 +426,7 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
   function compact(cb) {
     if (compaction) {
       debug('compaction already in progress')
+      waitingCompaction.push(cb)
       return
     }
     compaction = new Compaction(self, latestBlockIndex, (err) => {

--- a/index.js
+++ b/index.js
@@ -58,6 +58,14 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
   let compaction = null
   const waitingCompaction = []
 
+  onLoad(function maybeResumeCompaction() {
+    if (Compaction.stateFileExists(filename)) {
+      compact({}, function onCompactDone(err) {
+        if (err) throw err
+      })
+    }
+  })()
+
   raf.stat(function onRAFStatDone(err, stat) {
     if (err) debug('failed to stat ' + filename, err)
 
@@ -472,9 +480,8 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
       return stream
     },
 
-    // Internals:
-    filename,
     // Internals needed by ./compaction.js:
+    filename,
     blockSize,
     overwrite,
     truncate,

--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
   // -1: end of log
   //  0: need a new block
   // >0: next record within block
-  function getDataNextOffset(blockBuf, offset) {
+  function getDataNextOffset(blockBuf, offset, asRaw = false) {
     const offsetInBlock = getOffsetInBlock(offset)
     const [dataBuf, recSize] = Record.read(blockBuf, offsetInBlock)
     const nextLength = Record.readDataLength(blockBuf, offsetInBlock + recSize)
@@ -221,7 +221,7 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
     }
 
     if (isBufferZero(dataBuf)) return [nextOffset, null]
-    else return [nextOffset, codec.decode(dataBuf)]
+    else return [nextOffset, asRaw ? dataBuf : codec.decode(dataBuf)]
   }
 
   function del(offset, cb) {

--- a/index.js
+++ b/index.js
@@ -139,12 +139,12 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
   }
 
   function truncateWithFSync(newSize, cb) {
-    writeLock((unlock) => {
-      raf.del(newSize, Infinity, (err) => {
+    writeLock(function onWriteLockReleasedForTruncate(unlock) {
+      raf.del(newSize, Infinity, function onRAFDeleteDone(err) {
         if (err) return unlock(cb, err)
 
         if (raf.fd) {
-          fs.fsync(raf.fd, (err) => {
+          fs.fsync(raf.fd, function onFSyncDoneForTruncate(err) {
             if (err) unlock(cb, err)
             else unlock(cb, null)
           })

--- a/index.js
+++ b/index.js
@@ -443,7 +443,10 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
         compaction = null
         if (err) return cb(err)
         compactionProgress.set({ sizeDiff, percent: 1, done: true })
-        while (waitingCompaction.length) waitingCompaction.shift()()
+        for (let i = 0, n = waitingCompaction.length; i < n; ++i) {
+          waitingCompaction[i]()
+        }
+        waitingCompaction.length = 0
         cb()
       })
       compaction.progress((stats) => {

--- a/index.js
+++ b/index.js
@@ -395,6 +395,10 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
     function onDone(err, newLastBlockIndex) {
       compaction = null
       if (err) return cb(err)
+      if (newLastBlockIndex === latestBlockIndex) {
+        while (waitingCompaction.length) waitingCompaction.shift()()
+        return cb()
+      }
       // delete everything after newLastBlockIndex
       const newSize = newLastBlockIndex * blockSize
       debug('truncating all blocks after block #%d', newLastBlockIndex)

--- a/index.js
+++ b/index.js
@@ -399,7 +399,7 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
     if (lastBlockIndex >= latestBlockIndex) return cb()
     const newSize = lastBlockIndex * blockSize
     for (let i = lastBlockIndex + 1; i < latestBlockIndex; ++i) {
-      cache.delete(i)
+      cache.remove(i)
     }
     truncateWithFSync(newSize, (err) => {
       if (err) return cb(err)

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "nyc": "^15.1.0",
     "prettier": "^2.5.1",
     "pretty-quick": "^3.1.3",
+    "promisify-tuple": "^1.2.0",
     "pull-stream": "^3.6.14",
     "tap-spec": "^5.0.0",
     "tape": "^5.0.1",

--- a/test/basic.js
+++ b/test/basic.js
@@ -132,7 +132,7 @@ tape('transaction fail', function (t) {
   db.appendTransaction([json1, json2], function (err, offsets) {
     t.equal(
       err.message,
-      'data larger than block size',
+      'Data to be appended is larger than block size',
       'fails on too much data'
     )
     db.close(t.end)

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -349,7 +349,7 @@ tape('recovers from crash just after persisting state', async (t) => {
   t.pass('suppose compaction was in progress: [0x22, 0x33] and [0x33, 0x44]')
 
   const compactingBlockIndex = [1, 0] // uint16LE
-  const unshiftedOffset = [9 + 3 + 1, 0] // uint32LE
+  const unshiftedOffset = [9 + 3, 0] // uint32LE
   const unshiftedBlock = [
     [1, 0, 0x33],
     [1, 0, 0x44],
@@ -424,7 +424,7 @@ tape('recovers from crash just after persisting block', async (t) => {
   t.pass('suppose compaction was in progress: [0x22, 0x33] and [0x33, 0x44]')
 
   const compactingBlockIndex = [0, 0] // uint16LE
-  const unshiftedOffset = [0 + 1, 0] // uint32LE
+  const unshiftedOffset = [0, 0] // uint32LE
   const unshiftedBlock = [
     [2, 0, 0, 0], // deleted. used to be [2, 0, 0x11, 0x11]
     [1, 0, 0x22],

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -6,7 +6,7 @@ const tape = require('tape')
 const push = require('push-stream')
 const Log = require('../')
 
-tape('delete, compact, stream', (t) => {
+tape('delete first record, compact, stream', (t) => {
   const file = '/tmp/compaction-test_' + Date.now() + '.log'
   const log = Log(file, { blockSize: 10 })
 
@@ -14,21 +14,20 @@ tape('delete, compact, stream', (t) => {
   const buf2 = Buffer.from('second')
 
   log.append(buf1, (err, offset1) => {
-    t.error(err, 'no error')
     log.append(buf2, (err, offset2) => {
-      t.error(err, 'no error')
+      t.pass('append two records')
       log.onDrain(() => {
         log.del(offset1, (err) => {
-          t.error(err, 'no error')
+          t.pass('delete first record')
           log.onDrain(() => {
             log.compact({}, (err) => {
-              t.error(err, 'no error')
+              t.error(err, 'no error when compacting')
               log.onDrain(() => {
                 log.stream({ offsets: false }).pipe(
                   push.collect((err, ary) => {
-                    t.error(err, 'no error')
-                    t.deepEqual(ary, [buf2])
-                    t.end()
+                    t.error(err, 'no error when streaming compacted log')
+                    t.deepEqual(ary, [buf2], 'only second record exists')
+                    log.close(t.end)
                   })
                 )
               })
@@ -40,8 +39,118 @@ tape('delete, compact, stream', (t) => {
   })
 })
 
-tape.skip('delete the last record, then compact, then stream', (t) => {})
+tape('compaction does not happen on the last (work in progress) block', (t) => {
+  const file = '/tmp/compaction-test_' + Date.now() + '.log'
+  const log = Log(file, { blockSize: 10 })
 
-tape.skip('delete remaining blocks at the end after compaction', (t) => {
-  // FIXME:
+  const buf1 = Buffer.from('first')
+  const buf2 = Buffer.from('second')
+
+  log.append(buf1, (err, offset1) => {
+    log.append(buf2, (err, offset2) => {
+      t.pass('append two records')
+      log.onDrain(() => {
+        log.del(offset2, (err) => {
+          t.pass('delete second record')
+          log.onDrain(() => {
+            log.compact({}, (err) => {
+              t.error(err, 'no error when compacting')
+              log.onDrain(() => {
+                log.stream({ offsets: false }).pipe(
+                  push.collect((err, ary) => {
+                    t.error(err, 'no error when streaming compacted log')
+                    t.deepEqual(ary, [buf1, null], 'not compacted last block')
+                    log.close(t.end)
+                  })
+                )
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})
+
+tape('shift many blocks', (t) => {
+  const file = '/tmp/compaction-test_' + Date.now() + '.log'
+  const log = Log(file, {
+    blockSize: 11, // fits 3 records of size 3 plus EOB of size 2
+    codec: {
+      encode: (num) => Buffer.from(num.toString(16), 'hex'),
+      decode: (buf) => parseInt(buf.toString('hex'), 16),
+    },
+  })
+
+  log.append(
+    [
+      // block 0
+      [0x11, 0x22, 0x33], // offsets: 0, 3, 6
+      // block 1
+      [0x44, 0x55, 0x66], // offsets: 11+0, 11+3, 11+6
+      // block 2
+      [0x77, 0x88, 0x99], // offsets: 22+0, 22+3, 22+6
+      // block 3
+      [0xaa, 0xbb, 0xcc], // offsets: 33+0, 33+3, 33+6
+      // block 4
+      [0xdd, 0xee, 0xff], // offsets: 44+0, 44+3, 44+6
+    ].flat(),
+    (err, offsets) => {
+      t.pass('appended records')
+      log.del(11 + 3, (err) => {
+        log.del(11 + 6, (err) => {
+          log.del(33 + 3, (err) => {
+            t.pass('deleted some records in the middle')
+            log.onDrain(() => {
+              log.stream({ offsets: false }).pipe(
+                push.collect((err, ary) => {
+                  t.deepEqual(
+                    ary,
+                    [
+                      // block 0
+                      [0x11, 0x22, 0x33],
+                      // block 1
+                      [0x44, null, null],
+                      // block 2
+                      [0x77, 0x88, 0x99],
+                      // block 3
+                      [0xaa, null, 0xcc],
+                      // block 4
+                      [0xdd, 0xee, 0xff],
+                    ].flat(),
+                    'log has 4 blocks and some holes'
+                  )
+                  log.compact({}, (err) => {
+                    t.error(err, 'no error when compacting')
+                    log.onDrain(() => {
+                      log.stream({ offsets: false }).pipe(
+                        push.collect((err, ary) => {
+                          t.error(err, 'no error when streaming compacted log')
+                          t.deepEqual(
+                            ary,
+                            [
+                              // block 0
+                              [0x11, 0x22, 0x33],
+                              // block 1
+                              [0x44, 0x77, 0x88],
+                              // block 2
+                              [0x99, 0xaa, 0xcc],
+                              // block 3
+                              [0xdd, 0xee, 0xff],
+                            ].flat(),
+                            'log has 3 blocks and no holes'
+                          )
+                          log.close(t.end)
+                        })
+                      )
+                    })
+                  })
+                })
+              )
+            })
+          })
+        })
+      })
+    }
+  )
 })

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -177,6 +177,11 @@ tape('shift many blocks', async (t) => {
     )
   })
 
+  const progressArr = []
+  log.compactionSince((obj) => {
+    progressArr.push(obj)
+  })
+
   const [err] = await run(log.compact)()
   await run(log.onDrain)()
   t.error(err, 'no error when compacting')
@@ -203,6 +208,17 @@ tape('shift many blocks', async (t) => {
       })
     )
   })
+
+  t.deepEquals(
+    progressArr,
+    [
+      { value: 11 + 0, done: false },
+      { value: 22 + 6, done: false },
+      { value: 44 + 0, done: false },
+      { value: 11, done: true }, // the log is now 1 block shorter
+    ],
+    'progress events'
+  )
 
   await run(log.close)()
   t.end()

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 Anders Rune Jensen
+//
+// SPDX-License-Identifier: Unlicense
+
 const tape = require('tape')
 const push = require('push-stream')
 const Log = require('../')

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -124,7 +124,7 @@ tape('shift many blocks', async (t) => {
             // block 4
             [0xdd, 0xee, 0xff],
           ].flat(),
-          'log has 4 blocks and some holes'
+          'log has 5 blocks and some holes'
         )
         resolve()
       })
@@ -151,7 +151,7 @@ tape('shift many blocks', async (t) => {
             // block 3
             [0xdd, 0xee, 0xff],
           ].flat(),
-          'log has 3 blocks and no holes, except in the last block'
+          'log has 4 blocks and no holes, except in the last block'
         )
         resolve()
       })

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -25,7 +25,7 @@ tape('delete first record, compact, stream', async (t) => {
   await run(log.onDrain)()
   t.pass('delete first record')
 
-  const [err] = await run(log.compact)({})
+  const [err] = await run(log.compact)()
   await run(log.onDrain)()
   t.error(err, 'no error when compacting')
 
@@ -69,7 +69,7 @@ tape('delete second record, compact, stream', async (t) => {
     )
   })
 
-  const [err] = await run(log.compact)({})
+  const [err] = await run(log.compact)()
   await run(log.onDrain)()
   t.error(err, 'no error when compacting')
 
@@ -143,7 +143,7 @@ tape('shift many blocks', async (t) => {
     )
   })
 
-  const [err] = await run(log.compact)({})
+  const [err] = await run(log.compact)()
   await run(log.onDrain)()
   t.error(err, 'no error when compacting')
 
@@ -221,7 +221,7 @@ tape('compact handling last deleted record on last block', async (t) => {
     )
   })
 
-  const [err] = await run(log.compact)({})
+  const [err] = await run(log.compact)()
   await run(log.onDrain)()
   t.error(err, 'no error when compacting')
 
@@ -297,7 +297,7 @@ tape('compact handling holes of different sizes', async (t) => {
     )
   })
 
-  const [err] = await run(log.compact)({})
+  const [err] = await run(log.compact)()
   await run(log.onDrain)()
   t.error(err, 'no error when compacting')
 
@@ -493,7 +493,7 @@ tape('append during compaction is postponed', async (t) => {
 
   let appendDone = false
   let compactDone = false
-  log.compact({}, (err) => {
+  log.compact((err) => {
     t.error(err, 'no error when compacting')
     t.false(appendDone, 'compact was done before append')
     compactDone = true
@@ -538,7 +538,7 @@ tape('appendTransaction during compaction is postponed', async (t) => {
 
   let appendTransactionDone = false
   let compactDone = false
-  log.compact({}, (err) => {
+  log.compact((err) => {
     t.error(err, 'no error when compacting')
     t.false(appendTransactionDone, 'compact was done before appendTransaction')
     compactDone = true
@@ -580,7 +580,7 @@ tape('del during compaction is forbidden', async (t) => {
   await run(log.onDrain)()
   t.pass('delete first record')
 
-  log.compact({}, (err) => {
+  log.compact((err) => {
     t.error(err, 'no error when compacting')
   })
   const [err, offset3] = await run(log.del)(10)

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -348,8 +348,8 @@ tape('recovers from crash just after persisting state', async (t) => {
   await run(log.close)()
   t.pass('suppose compaction was in progress: [0x22, 0x33] and [0x33, 0x44]')
 
-  const compactingBlockIndex = [1, 0] // uint16LE
-  const unshiftedOffset = [9 + 3, 0] // uint32LE
+  const compactingBlockIndex = [1, 0, 0, 0] // uint32LE
+  const unshiftedOffset = [9 + 3, 0, 0, 0] // uint32LE
   const unshiftedBlock = [
     [1, 0, 0x33],
     [1, 0, 0x44],
@@ -423,8 +423,8 @@ tape('recovers from crash just after persisting block', async (t) => {
   await run(log.close)()
   t.pass('suppose compaction was in progress: [0x22, 0x33] and [0x33, 0x44]')
 
-  const compactingBlockIndex = [0, 0] // uint16LE
-  const unshiftedOffset = [0, 0] // uint32LE
+  const compactingBlockIndex = [0, 0, 0, 0] // uint32LE
+  const unshiftedOffset = [0, 0, 0, 0] // uint32LE
   const unshiftedBlock = [
     [2, 0, 0, 0], // deleted. used to be [2, 0, 0x11, 0x11]
     [1, 0, 0x22],

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -1,0 +1,43 @@
+const tape = require('tape')
+const push = require('push-stream')
+const Log = require('../')
+
+tape('delete, compact, stream', (t) => {
+  const file = '/tmp/compaction-test_' + Date.now() + '.log'
+  const log = Log(file, { blockSize: 10 })
+
+  const buf1 = Buffer.from('first')
+  const buf2 = Buffer.from('second')
+
+  log.append(buf1, (err, offset1) => {
+    t.error(err, 'no error')
+    log.append(buf2, (err, offset2) => {
+      t.error(err, 'no error')
+      log.onDrain(() => {
+        log.del(offset1, (err) => {
+          t.error(err, 'no error')
+          log.onDrain(() => {
+            log.compact({}, (err) => {
+              t.error(err, 'no error')
+              log.onDrain(() => {
+                log.stream({ offsets: false }).pipe(
+                  push.collect((err, ary) => {
+                    t.error(err, 'no error')
+                    t.deepEqual(ary, [buf2])
+                    t.end()
+                  })
+                )
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})
+
+tape.skip('delete the last record, then compact, then stream', (t) => {})
+
+tape.skip('delete remaining blocks at the end after compaction', (t) => {
+  // FIXME:
+})

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -354,6 +354,7 @@ tape('recovers from crash just after persisting state', async (t) => {
     ])
   )
   t.pass('suppose compaction file: blockIndex 1, unshifted 12, [0x33, 0x44]')
+  t.true(fs.existsSync(file + '.compaction'), 'compaction file exists')
 
   log = Log(file, { blockSize: 9, codec: hexCodec })
   t.pass('start log, compaction should autostart')
@@ -378,6 +379,8 @@ tape('recovers from crash just after persisting state', async (t) => {
       })
     )
   })
+
+  t.false(fs.existsSync(file + '.compaction'), 'compaction file is autodeleted')
 
   await run(log.close)()
   t.end()

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -9,6 +9,11 @@ const run = require('promisify-tuple')
 const timer = require('util').promisify(setTimeout)
 const Log = require('../')
 
+const hexCodec = {
+  encode: (num) => Buffer.from(num.toString(16), 'hex'),
+  decode: (buf) => parseInt(buf.toString('hex'), 16),
+}
+
 tape('delete first record, compact, stream', async (t) => {
   const file = '/tmp/compaction-test_' + Date.now() + '.log'
   const log = Log(file, { blockSize: 10 })
@@ -91,10 +96,7 @@ tape('shift many blocks', async (t) => {
   const file = '/tmp/compaction-test_' + Date.now() + '.log'
   const log = Log(file, {
     blockSize: 11, // fits 3 records of size 3 plus EOB of size 2
-    codec: {
-      encode: (num) => Buffer.from(num.toString(16), 'hex'),
-      decode: (buf) => parseInt(buf.toString('hex'), 16),
-    },
+    codec: hexCodec,
   })
 
   await run(log.append)(
@@ -178,10 +180,7 @@ tape('compact handling last deleted record on last block', async (t) => {
   const file = '/tmp/compaction-test_' + Date.now() + '.log'
   const log = Log(file, {
     blockSize: 11, // fits 3 records of size 3 plus EOB of size 2
-    codec: {
-      encode: (num) => Buffer.from(num.toString(16), 'hex'),
-      decode: (buf) => parseInt(buf.toString('hex'), 16),
-    },
+    codec: hexCodec,
   })
 
   await run(log.append)(
@@ -254,10 +253,7 @@ tape('compact handling holes of different sizes', async (t) => {
   const file = '/tmp/compaction-test_' + Date.now() + '.log'
   const log = Log(file, {
     blockSize: 14, // fits 4 records of size 3 plus EOB of size 2
-    codec: {
-      encode: (num) => Buffer.from(num.toString(16), 'hex'),
-      decode: (buf) => parseInt(buf.toString('hex'), 16),
-    },
+    codec: hexCodec,
   })
 
   await run(log.append)(
@@ -327,13 +323,7 @@ tape('compact handling holes of different sizes', async (t) => {
 tape('recovers from crash just after persisting state', async (t) => {
   t.timeoutAfter(6000)
   const file = '/tmp/compaction-test_' + Date.now() + '.log'
-  let log = Log(file, {
-    blockSize: 9,
-    codec: {
-      encode: (num) => Buffer.from(num.toString(16), 'hex'),
-      decode: (buf) => parseInt(buf.toString('hex'), 16),
-    },
-  })
+  let log = Log(file, { blockSize: 9, codec: hexCodec })
   t.pass('suppose the log has blockSize 9')
   t.pass('suppose we had blocks: [null, 0x22] and [0x33, 0x44]')
 
@@ -365,13 +355,7 @@ tape('recovers from crash just after persisting state', async (t) => {
   )
   t.pass('suppose compaction file: blockIndex 1, unshifted 12, [0x33, 0x44]')
 
-  log = Log(file, {
-    blockSize: 9,
-    codec: {
-      encode: (num) => Buffer.from(num.toString(16), 'hex'),
-      decode: (buf) => parseInt(buf.toString('hex'), 16),
-    },
-  })
+  log = Log(file, { blockSize: 9, codec: hexCodec })
   t.pass('start log, compaction should autostart')
 
   await timer(1000)
@@ -402,13 +386,7 @@ tape('recovers from crash just after persisting state', async (t) => {
 tape('recovers from crash just after persisting block', async (t) => {
   t.timeoutAfter(6000)
   const file = '/tmp/compaction-test_' + Date.now() + '.log'
-  let log = Log(file, {
-    blockSize: 9,
-    codec: {
-      encode: (num) => Buffer.from(num.toString(16), 'hex'),
-      decode: (buf) => parseInt(buf.toString('hex'), 16),
-    },
-  })
+  let log = Log(file, { blockSize: 9, codec: hexCodec })
   t.pass('suppose the log has blockSize 9')
   t.pass('suppose we had blocks: [null, 0x22] and [0x33, 0x44]')
 
@@ -440,13 +418,7 @@ tape('recovers from crash just after persisting block', async (t) => {
   )
   t.pass('suppose compaction file: blockIndex 0, unshifted 0, [null, 0x22]')
 
-  log = Log(file, {
-    blockSize: 9,
-    codec: {
-      encode: (num) => Buffer.from(num.toString(16), 'hex'),
-      decode: (buf) => parseInt(buf.toString('hex'), 16),
-    },
-  })
+  log = Log(file, { blockSize: 9, codec: hexCodec })
   t.pass('start log, compaction should autostart')
 
   await timer(1000)


### PR DESCRIPTION
- [x] In-memory compaction
- [x] Persist compacted blocks and truncate shifted blocks
- [x] State file `$filename.compaction` for cold restarts
- [x] Protect `log.append` API during compaction
- [x] Protect `log.appendTransaction` API during compaction
- [x] Protect `log.del` API during compaction
- [x] Compact needs to wait for all writes to flush first
- [x] ~~Protect `log.get` API during compaction~~
- [x] ~~Protect `log.stream` API during compaction~~
- [x] Stream or obz to track compaction progress
- [x] After truncating, update `latestBlockBuf` and `latestBlockIndex` etc
- [x] ~~What about concurrent `del` and `append` on the same block?~~ #62

Things to be reviewed:

- Are we really okay with not protecting `log.get` and `log.stream` being called during compaction?
- What should we do with `log.since` once compaction is done? Set it to the new latest offset? And how will ssb-db2 react when the log.since is now smaller?