### PR TITLE
refactor onLoad

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -55,7 +55,7 @@ function Stream(log, opts) {
   this._resumeCallback = this._resumeCallback.bind(this)
   this._resume = this._resume.bind(this)
 
-  this.log.onReady(this._ready.bind(this))
+  this.log.onLoad(this._ready.bind(this))()
 }
 
 Stream.prototype._ready = function _ready() {

--- a/test/basic.js
+++ b/test/basic.js
@@ -76,7 +76,7 @@ tape('basic json re-read', function (t) {
     codec: require('flumecodec/json'),
   })
 
-  db.onReady(() => {
+  db.onDrain(() => {
     t.equal(db.since.value, 20)
     db.get(0, function (err, buf) {
       if (err) throw err

--- a/test/fix-buggy-write.js
+++ b/test/fix-buggy-write.js
@@ -46,7 +46,7 @@ tape('simple reread', function (t) {
     codec: require('flumecodec/json'),
   })
 
-  db.onReady(() => {
+  db.onDrain(() => {
     db.stream({ offsets: false }).pipe(
       push.collect((err, ary) => {
         t.deepEqual(ary, [msg1, msg2])

--- a/test/fix-concurrency-write-drain-bug.js
+++ b/test/fix-concurrency-write-drain-bug.js
@@ -22,7 +22,7 @@ tape('check since after drain', async (t) => {
     })
 
     await new Promise((resolve, reject) => {
-      db.onReady(() => {
+      db.onDrain(() => {
         db.append(msg1, (err, offset1) => {
           if (err) reject(err)
 

--- a/test/jacob.js
+++ b/test/jacob.js
@@ -40,7 +40,7 @@ tape('corrupt message re-read without validation', function (t) {
   var file = '/tmp/jacob.log'
   var db = Log(file, { blockSize: 64 * 1024 })
 
-  db.onReady(() => {
+  db.onDrain(() => {
     var result = []
 
     db.stream({ offsets: false }).pipe({
@@ -71,7 +71,7 @@ tape('corrupt message re-read with validation', function (t) {
     },
   })
 
-  db.onReady(() => {
+  db.onDrain(() => {
     var result = []
 
     db.stream({ offsets: false }).pipe({
@@ -115,7 +115,7 @@ tape('length re-read without validation', function (t) {
     blockSize: 64 * 1024,
   })
 
-  db.onReady(() => {
+  db.onDrain(() => {
     var result = []
 
     db.stream({ offsets: false }).pipe({
@@ -151,7 +151,7 @@ tape('length re-read with validation', function (t) {
     },
   })
 
-  db.onReady(() => {
+  db.onDrain(() => {
     var result = []
 
     db.stream({ offsets: false }).pipe({


### PR DESCRIPTION
I'm already working on compaction (PR #55), but I noticed this: we have both `onReady` and `onLoad`, which do basically the same thing. Also, `onLoad` only supported functions with two arguments: `(input, cb) =>` so it would not work in case we added another API with 3 or more arguments. This PR changes that.