### PR TITLE
speed up hole detection by 400x

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const Cache = require('hashlru')
 const RAF = require('polyraf')
 const Obv = require('obz')
 const debounce = require('lodash.debounce')
+const isZeroBuf = require('is-zero-buffer')
 const debug = require('debug')('async-append-only-log')
 const fs = require('fs')
 const mutexify = require('mutexify')
@@ -169,7 +170,7 @@ module.exports = function (filename, opts) {
   function getData(blockBuf, offsetInBlock, cb) {
     const [dataBuf] = Record.read(blockBuf, offsetInBlock)
 
-    if (dataBuf.every((x) => x === 0)) {
+    if (isZeroBuf(dataBuf)) {
       const err = new Error('item has been deleted')
       err.code = 'ERR_AAOL_DELETED_RECORD'
       return cb(err)
@@ -204,7 +205,7 @@ module.exports = function (filename, opts) {
       nextOffset = offset + recSize
     }
 
-    if (dataBuf.every((x) => x === 0)) return [nextOffset, null]
+    if (isZeroBuf(dataBuf)) return [nextOffset, null]
     else return [nextOffset, codec.decode(dataBuf)]
   }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "debug": "^4.2.0",
     "hashlru": "^2.3.0",
+    "is-zero-buffer": "^1.0.1",
     "lodash.debounce": "^4.0.8",
     "looper": "^4.0.0",
     "ltgt": "^2.2.1",


### PR DESCRIPTION
I had a hunch that `buf.every((x) => x === 0)` is probably slow, so I did some research, and ended up finding this lovely module by mafintosh: https://github.com/mafintosh/is-zero-buffer

I ran these simple benchmarks:

```js
var isZero = (buf) => buf.every(x => x === 0)

var buf = Buffer.alloc(65536)
var then = Date.now()

for (var i = 0; i < 100000; i++) {
  isZero(buf)
}

console.log(Date.now() - then)
```

```js
var isZero = require('is-zero-buffer')

var buf = Buffer.alloc(65536)
var then = Date.now()

for (var i = 0; i < 100000; i++) {
  isZero(buf)
}

console.log(Date.now() - then)
```

And the numbers are ridiculous:

- ~`99491` milliseconds
- ~`225` milliseconds

Easy win!