### PR TITLE
Use is-buffer-zero to check for deleted records

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const Cache = require('hashlru')
 const RAF = require('polyraf')
 const Obv = require('obz')
 const debounce = require('lodash.debounce')
+const isBufferZero = require('is-buffer-zero')
 const debug = require('debug')('async-append-only-log')
 const fs = require('fs')
 const mutexify = require('mutexify')
@@ -169,7 +170,7 @@ module.exports = function (filename, opts) {
   function getData(blockBuf, offsetInBlock, cb) {
     const [dataBuf] = Record.read(blockBuf, offsetInBlock)
 
-    if (dataBuf.every((x) => x === 0)) {
+    if (isBufferZero(dataBuf)) {
       const err = new Error('item has been deleted')
       err.code = 'ERR_AAOL_DELETED_RECORD'
       return cb(err)
@@ -204,7 +205,7 @@ module.exports = function (filename, opts) {
       nextOffset = offset + recSize
     }
 
-    if (dataBuf.every((x) => x === 0)) return [nextOffset, null]
+    if (isBufferZero(dataBuf)) return [nextOffset, null]
     else return [nextOffset, codec.decode(dataBuf)]
   }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "debug": "^4.2.0",
     "hashlru": "^2.3.0",
+    "is-buffer-zero": "^1.0.0",
     "lodash.debounce": "^4.0.8",
     "looper": "^4.0.0",
     "ltgt": "^2.2.1",


### PR DESCRIPTION
Fixes #59 

I ran the benchmarks in jitdb with this and it appears we have the same numbers in the normal case. The microbenchmarks confirms this: https://github.com/arj03/is-buffer-zero