### PR TITLE
protect del() from concurrency on the latest block

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,6 +214,12 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
   }
 
   function del(offset, cb) {
+    if (blocksToBeWritten.has(getBlockIndex(offset))) {
+      onDrain(function delAfterDrained() {
+        del(offset, cb)
+      })
+      return
+    }
     getBlock(offset, function gotBlockForDelete(err, blockBuf) {
       if (err) return cb(err)
       Record.overwriteWithZeroes(blockBuf, getOffsetInBlock(offset))


### PR DESCRIPTION
I'm trying to address "*What about concurrent del and append on the same block?*" from PR #55, and I realized that we only need to protect `del()` happening on the latest block, because no writes can be done to previous blocks anyway.

I am actually not sure if this PR is the right way. One question that came to mind: if you do a `del()` and an `onDrain(cb)`, then the onDrain's `cb` should let you read blocks where the state is "updated" with the delete, right? So technically `onDrain()` should wait for the `del()` to happen. But that's not currently happening.