### PR TITLE
Revisit errors thrown from log.get

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -1,0 +1,39 @@
+class ErrorWithCode extends Error {
+  constructor(message, code) {
+    super(message)
+    this.code = code
+  }
+}
+
+function nanOffsetErr(offset) {
+  return new ErrorWithCode(
+    `Offset ${offset} is not a number`,
+    'ERR_AAOL_INVALID_OFFSET'
+  )
+}
+
+function negativeOffsetErr(offset) {
+  return new ErrorWithCode(
+    `Offset ${offset} is negative`,
+    'ERR_AAOL_INVALID_OFFSET'
+  )
+}
+
+function outOfBoundsOffsetErr(offset, logSize) {
+  return new ErrorWithCode(
+    `Offset ${offset} is beyond log size ${logSize}`,
+    'ERR_AAOL_OFFSET_OUT_OF_BOUNDS'
+  )
+}
+
+function deletedRecordErr() {
+  return new ErrorWithCode('Record has been deleted', 'ERR_AAOL_DELETED_RECORD')
+}
+
+module.exports = {
+  ErrorWithCode,
+  nanOffsetErr,
+  negativeOffsetErr,
+  outOfBoundsOffsetErr,
+  deletedRecordErr,
+}

--- a/errors.js
+++ b/errors.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 Anders Rune Jensen
+//
+// SPDX-License-Identifier: LGPL-3.0-only
+
 class ErrorWithCode extends Error {
   constructor(message, code) {
     super(message)

--- a/index.js
+++ b/index.js
@@ -174,9 +174,12 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
   }
 
   function get(offset, cb) {
-    if (typeof offset !== 'number' || isNaN(offset))
-      return cb(`Offset ${offset} is not a number`)
-    else if (offset < 0) return cb(`Offset is ${offset} must be >= 0`)
+    if (typeof offset !== 'number' || isNaN(offset)) {
+      return cb(new Error(`Offset ${offset} is not a number`))
+    }
+    if (offset < 0) {
+      return cb(new Error(`Offset ${offset} is negative`))
+    }
 
     getBlock(offset, function gotBlock(err, blockBuf) {
       if (err) return cb(err)

--- a/index.js
+++ b/index.js
@@ -180,6 +180,10 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
     if (offset < 0) {
       return cb(new Error(`Offset ${offset} is negative`))
     }
+    const logSize = latestBlockIndex * blockSize + nextOffsetInBlock - 1
+    if (offset > logSize) {
+      return cb(new Error(`Offset ${offset} is beyond log size ${logSize}`))
+    }
 
     getBlock(offset, function gotBlock(err, blockBuf) {
       if (err) return cb(err)

--- a/test/bad-offset.js
+++ b/test/bad-offset.js
@@ -45,3 +45,22 @@ tape('-1', function (t) {
     })
   })
 })
+
+tape('beyond log size', function (t) {
+  var file = '/tmp/dsf-test-bad-offset.log'
+  try {
+    fs.unlinkSync(file)
+  } catch (_) {}
+  var db = Log(file, { blockSize: 2 * 1024 })
+
+  var msg2 = Buffer.from('testing')
+
+  db.append(msg2, function (err, offset1) {
+    if (err) throw err
+    t.equal(offset1, 0)
+    db.get(10240, function (err, b) {
+      t.match(err.message, /Offset 10240 is beyond log size/, err.message)
+      db.close(t.end)
+    })
+  })
+})

--- a/test/bad-offset.js
+++ b/test/bad-offset.js
@@ -19,7 +19,8 @@ tape('NaN', function (t) {
     if (err) throw err
     t.equal(offset1, 0)
     db.get(NaN, function (err, b) {
-      t.equal(err, 'Offset NaN is not a number')
+      t.ok(err)
+      t.match(err.message, /Offset NaN is not a number/, err.message)
       db.close(t.end)
     })
   })
@@ -38,7 +39,8 @@ tape('-1', function (t) {
     if (err) throw err
     t.equal(offset1, 0)
     db.get(-1, function (err, b) {
-      t.equal(err, 'Offset is -1 must be >= 0')
+      t.ok(err)
+      t.match(err.message, /Offset -1 is negative/, err.message)
       db.close(t.end)
     })
   })

--- a/test/bad-offset.js
+++ b/test/bad-offset.js
@@ -21,6 +21,7 @@ tape('NaN', function (t) {
     db.get(NaN, function (err, b) {
       t.ok(err)
       t.match(err.message, /Offset NaN is not a number/, err.message)
+      t.equals(err.code, 'ERR_AAOL_INVALID_OFFSET')
       db.close(t.end)
     })
   })
@@ -41,12 +42,13 @@ tape('-1', function (t) {
     db.get(-1, function (err, b) {
       t.ok(err)
       t.match(err.message, /Offset -1 is negative/, err.message)
+      t.equals(err.code, 'ERR_AAOL_INVALID_OFFSET')
       db.close(t.end)
     })
   })
 })
 
-tape('beyond log size', function (t) {
+tape('out of bounds', function (t) {
   var file = '/tmp/dsf-test-bad-offset.log'
   try {
     fs.unlinkSync(file)
@@ -59,7 +61,9 @@ tape('beyond log size', function (t) {
     if (err) throw err
     t.equal(offset1, 0)
     db.get(10240, function (err, b) {
+      t.ok(err)
       t.match(err.message, /Offset 10240 is beyond log size/, err.message)
+      t.equals(err.code, 'ERR_AAOL_OFFSET_OUT_OF_BOUNDS')
       db.close(t.end)
     })
   })

--- a/test/delete.js
+++ b/test/delete.js
@@ -49,7 +49,8 @@ tape('simple', function (t) {
 
                 db.get(offset3, function (err, deletedBuf) {
                   t.ok(err)
-                  t.equal(err.message, 'item has been deleted')
+                  t.equal(err.message, 'Record has been deleted')
+                  t.equal(err.code, 'ERR_AAOL_DELETED_RECORD')
                   // write changes
                   db.onDrain(t.end)
                 })
@@ -80,14 +81,16 @@ tape('simple reread', function (t) {
 
       db.get(offset3, function (err) {
         t.ok(err)
-        t.equal(err.message, 'item has been deleted')
+        t.equal(err.message, 'Record has been deleted')
+        t.equal(err.code, 'ERR_AAOL_DELETED_RECORD')
 
         db.del(offset2, function (err) {
           t.error(err)
 
           db.get(offset2, function (err, deletedBuf) {
             t.ok(err)
-            t.equal(err.message, 'item has been deleted')
+            t.equal(err.message, 'Record has been deleted')
+            t.equal(err.code, 'ERR_AAOL_DELETED_RECORD')
             // write changes
             db.close(t.end)
           })
@@ -107,7 +110,8 @@ tape('simple reread 2', function (t) {
 
     db.get(msg1.length + 2, function (err, deletedBuf) {
       t.ok(err)
-      t.equal(err.message, 'item has been deleted')
+      t.equal(err.message, 'Record has been deleted')
+      t.equal(err.code, 'ERR_AAOL_DELETED_RECORD')
 
       t.end()
     })


### PR DESCRIPTION
- [throw errors, not strings, from log.get](https://github.com/ssb-ngi-pointer/async-append-only-log/commit/6f459d1ee840e8deb054b6e5d362ad4d72990158)
- [throw error if log.get has too large offset](https://github.com/ssb-ngi-pointer/async-append-only-log/commit/832f54c0878da3906a96cf8d430e64e8e425ef76)
  - This is a bit more relevant now for truncated logs after compact is done, because it's possible that the consumer code has references to outdated offsets
- [use err.code for log.get errors](https://github.com/ssb-ngi-pointer/async-append-only-log/pull/64/commits/3d24638e7d3b69eeba5a867ad93928a4bff95950)
  - `ERR_AAOL_OFFSET_OUT_OF_BOUNDS` is going to be useful for jitdb and ssb-db2, I think
- [refactor log.get internals](https://github.com/ssb-ngi-pointer/async-append-only-log/pull/64/commits/091d43fd4b362458bb78f383f93d5babaf9e5619)
  - `getData` and `get` seemed like an unnecessary split
- [refactor errors to errors.js file](https://github.com/ssb-ngi-pointer/async-append-only-log/pull/64/commits/b20844fd5535ea27243d7074e5c02a61b57bf19a)
  - trying to manage errors that have codes, without cluttering the control flow of the algorithm