### PR TITLE
speed up deletes and add onDeletesFlushed()

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ log.appendTransaction([item1, item2, item3], (err, offset3) => {
 })
 ```
 
+### Wait for all ongoing appends to be flushed to disk
+
+```js
+log.onDrain(() => {
+  // ...
+})
+```
+
 ### Scan all records as a `push-stream`
 
 ```js
@@ -160,10 +168,10 @@ log.del(offset, (err) => {
 })
 ```
 
-### Wait for all ongoing writes to complete
+### Wait for all ongoing deletes to be flushed to disk
 
 ```js
-log.onDrain(() => {
+log.onDeletesFlushed(() => {
   // ...
 })
 ```

--- a/index.js
+++ b/index.js
@@ -262,8 +262,9 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
     }
     function gotBlockForDelete(err, blockBuf) {
       if (err) return cb(err)
-      Record.overwriteWithZeroes(blockBuf, getOffsetInBlock(offset))
-      blocksWithDeletables.set(blockIndex, blockBuf)
+      const actualBlockBuf = blocksWithDeletables.get(blockIndex) || blockBuf
+      Record.overwriteWithZeroes(actualBlockBuf, getOffsetInBlock(offset))
+      blocksWithDeletables.set(blockIndex, actualBlockBuf)
       scheduleFlushDelete()
       cb()
     }

--- a/index.js
+++ b/index.js
@@ -253,13 +253,20 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
       })
       return
     }
-    getBlock(offset, function gotBlockForDelete(err, blockBuf) {
+
+    if (blocksWithDeletables.has(blockIndex)) {
+      const blockBuf = blocksWithDeletables.get(blockIndex)
+      gotBlockForDelete(null, blockBuf)
+    } else {
+      getBlock(offset, gotBlockForDelete)
+    }
+    function gotBlockForDelete(err, blockBuf) {
       if (err) return cb(err)
       Record.overwriteWithZeroes(blockBuf, getOffsetInBlock(offset))
       blocksWithDeletables.set(blockIndex, blockBuf)
       scheduleFlushDelete()
       cb()
-    })
+    }
   }
 
   function hasNoSpaceFor(dataBuf, offsetInBlock) {

--- a/test/delete.js
+++ b/test/delete.js
@@ -4,6 +4,7 @@
 
 var tape = require('tape')
 var fs = require('fs')
+var pify = require('util').promisify
 var push = require('push-stream')
 var Log = require('../')
 
@@ -47,12 +48,14 @@ tape('simple', function (t) {
               db.del(offset3, function (err) {
                 t.error(err)
 
-                db.get(offset3, function (err, deletedBuf) {
-                  t.ok(err)
-                  t.equal(err.message, 'Record has been deleted')
-                  t.equal(err.code, 'ERR_AAOL_DELETED_RECORD')
-                  // write changes
-                  db.onDrain(t.end)
+                db.onDeletesFlushed(() => {
+                  db.get(offset3, function (err, deletedBuf) {
+                    t.ok(err)
+                    t.equal(err.message, 'Record has been deleted')
+                    t.equal(err.code, 'ERR_AAOL_DELETED_RECORD')
+                    // write changes
+                    db.onDrain(t.end)
+                  })
                 })
               })
             })
@@ -87,12 +90,14 @@ tape('simple reread', function (t) {
         db.del(offset2, function (err) {
           t.error(err)
 
-          db.get(offset2, function (err, deletedBuf) {
-            t.ok(err)
-            t.equal(err.message, 'Record has been deleted')
-            t.equal(err.code, 'ERR_AAOL_DELETED_RECORD')
-            // write changes
-            db.close(t.end)
+          db.onDeletesFlushed(() => {
+            db.get(offset2, function (err, deletedBuf) {
+              t.ok(err)
+              t.equal(err.message, 'Record has been deleted')
+              t.equal(err.code, 'ERR_AAOL_DELETED_RECORD')
+              // write changes
+              db.close(t.end)
+            })
           })
         })
       })
@@ -109,11 +114,12 @@ tape('simple reread 2', function (t) {
     t.equal(buf.toString(), msg1.toString())
 
     db.get(msg1.length + 2, function (err, deletedBuf) {
+      console.log(deletedBuf)
       t.ok(err)
       t.equal(err.message, 'Record has been deleted')
       t.equal(err.code, 'ERR_AAOL_DELETED_RECORD')
 
-      t.end()
+      db.close(t.end)
     })
   })
 })
@@ -131,15 +137,51 @@ tape('stream delete', function (t) {
       db.del(offset1, function (err) {
         t.error(err)
         db.onDrain(() => {
-          db.stream({ offsets: false }).pipe(
-            push.collect((err, ary) => {
-              t.notOk(err)
-              t.deepEqual(ary, [null, buf2])
-              t.end()
-            })
-          )
+          db.onDeletesFlushed(() => {
+            db.stream({ offsets: false }).pipe(
+              push.collect((err, ary) => {
+                t.notOk(err)
+                t.deepEqual(ary, [null, buf2])
+                db.close(t.end)
+              })
+            )
+          })
         })
       })
     })
   })
+})
+
+tape('delete many', async (t) => {
+  t.timeoutAfter(60e3)
+  const file = '/tmp/aaol-test-delete-many' + Date.now() + '.log'
+  const log = Log(file, { blockSize: 64 * 1024 })
+
+  const TOTAL = 100000
+  const offsets = []
+  const logAppend = pify(log.append)
+  console.time('append ' + TOTAL)
+  for (let i = 0; i < TOTAL; i += 1) {
+    const offset = await logAppend(Buffer.from(`hello ${i}`))
+    offsets.push(offset)
+  }
+  t.pass('appended records')
+  console.timeEnd('append ' + TOTAL)
+
+  await pify(log.onDrain)()
+
+  await pify(setTimeout)(2000)
+
+  const logDel = pify(log.del)
+  console.time('delete ' + TOTAL)
+  for (let i = 0; i < TOTAL; i += 2) {
+    await logDel(offsets[i])
+  }
+  console.timeEnd('delete ' + TOTAL)
+  t.pass('deleted messages')
+
+  await pify(log.onDeletesFlushed)()
+
+  await pify(log.close)()
+  t.end()
 })


### PR DESCRIPTION
For issue https://github.com/ssb-ngi-pointer/ssb-db2/issues/334

@arj03 I don't think this PR is ready but I want to ask you a couple questions.

I'm using a batching strategy similar to `scheduleWrite` for the deletes. The results are pretty nice:

**Before:**

```
append 1000 records: 125.351ms
delete 1000 records: 897.869ms
```

**After:**

```
append 1000 records: 107.628ms
delete 1000 records: 19.421ms
```

I suspect it got faster than append because deletes use `buffer.fill` while appends use `buffer.copy`.

Issues:

- I added the new API `onFlushDelete` which is like `onDrain` but for deletes. I don't think this is great, I would have wanted that `onDrain` also waits for deletes to end, but it's tricky because `onDrain` just adds CBs to the `latestBlockIndex`, but deletes can happen on any block. Any thoughts about this?
- There are probably N corner cases with concurrency problems between append and delete. Like deletes on a "blockToBeWritten" is going to be postponed with `onDrain`, but not if the delete is for an older block while there are appends queued up for the lastBlockIndex. This is probably a mine field, have to walk carefully here, which is why the PR is a draft.