### PR TITLE
Crash before truncate

### DIFF
--- a/compaction.js
+++ b/compaction.js
@@ -78,10 +78,7 @@ function PersistentState(logFilename, blockSize) {
     if (stateFileExists(logFilename)) {
       raf.close(function onRAFClosed(err) {
         if (err) return cb(err)
-        fs.unlink(raf.filename, function onStateFileDeleted(err) {
-          if (err) return cb(err)
-          else cb()
-        })
+        fs.unlink(raf.filename, cb)
       })
     } else {
       cb()
@@ -163,11 +160,9 @@ function Compaction(log, onDone) {
 
   function savePersistentState(cb) {
     if (!unshiftedBlockBuf) {
-      loadUnshiftedBlock(function onUnshiftedBlockLoaded() {
-        saveIt.call(this)
-      })
+      loadUnshiftedBlock(saveIt)
     } else {
-      saveIt.call(this)
+      saveIt()
     }
 
     function saveIt() {
@@ -249,9 +244,7 @@ function Compaction(log, onDone) {
     while (true) {
       // Fetch the unshifted block, if necessary
       if (!unshiftedBlockBuf) {
-        loadUnshiftedBlock(function onUnshiftedBlockLoaded() {
-          continueCompactingBlock()
-        })
+        loadUnshiftedBlock(continueCompactingBlock)
         return
       }
       // When all records have been shifted (thus end of log), stop compacting
@@ -273,7 +266,7 @@ function Compaction(log, onDone) {
       // Proceed to compact the next block if this block is full
       if (log.hasNoSpaceFor(unshiftedDataBuf, offsetInCompactedBlock)) {
         saveCompactedBlock()
-        setImmediate(() => compactNextBlock())
+        setImmediate(compactNextBlock)
         return
       }
 


### PR DESCRIPTION
## Problem

After the compaction state file is destroyed, but *before* log.truncate is done, the program could crash. And then, when restarting the program, it wouldn't find any state file and would not auto-restart the compaction algorithm, leaving the log un-truncated and no space would be freed up.

```js
  function stop() {
    compactedBlockBuf = null
    unshiftedBlockBuf = null
    persistentState.destroy(function onCompactionStateDestroyed(err) {
      if (err) return onDone(err)
      // CRASH AT THIS POINT <----
      log.truncate(compactedBlockIndex, onDone)
    })
  }
```

## Solution

Save also `truncateBlockIndex` in the state file so we handle these kinds of crashes.

Also introduces a `version` field in the state file. Technically this PR introduces the **2nd** file format version, but I believe no one used compaction in production, so it's safe to declare this the 1st version. Anyone, versioning would have been very important if we had to do this file format change had log compaction already been in production.
