### PR TITLE
first compactionProgress events should have startOffset

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,11 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
   let nextOffsetInBlock = null
   const since = Obv() // offset of last written record
   let compaction = null
-  const compactionProgress = Obv()
+  const compactionProgress = Obv().set(
+    Compaction.stateFileExists(filename)
+      ? { done: false }
+      : { sizeDiff: 0, percent: 1, done: true }
+  )
   const waitingCompaction = []
 
   onLoad(function maybeResumeCompaction() {


### PR DESCRIPTION
## Problem 1

Other libraries like jitdb and ssb-db2 need to know whether compaction is happening or not (as a boolean). But in `master` branch, if there was no compaction yet, then `compactionProgress` would emit nothing and those libraries would not have a sure way of knowing that it's not happening yet.

## Problem 2

When restarting compaction from a crash, the `startOffset` emitted in `compactionProgress` has to be the same value as it would have been if compaction had just started, because the `startOffset` is important to know where the jitdb reindexing should start from.

## Solution

`startOffset` is saved in the compaction state file, and when AAOL is init'ed, it immediately emits an event on `compactionProgress` so that other libraries can read `compactionProgress.value` and know whether there's something ongoing or not.
