### PR TITLE
use sizeDiff=1 to represent holes filled

### DIFF
--- a/index.js
+++ b/index.js
@@ -485,10 +485,10 @@ module.exports = function AsyncAppendOnlyLog(filename, opts) {
     }
     onDrain(function startCompactAfterDrain() {
       onDeletesFlushed(function startCompactAfterDeletes() {
-        compaction = new Compaction(self, (err, sizeDiff) => {
+        compaction = new Compaction(self, (err, stats) => {
           compaction = null
           if (err) return cb(err)
-          compactionProgress.set({ sizeDiff, percent: 1, done: true })
+          compactionProgress.set({ ...stats, percent: 1, done: true })
           for (const callback of waitingCompaction) callback()
           waitingCompaction.length = 0
           cb()


### PR DESCRIPTION
Context: https://github.com/ssb-ngi-pointer/jitdb/issues/199

## Problem

In my ssb-db2 PR https://github.com/ssb-ngi-pointer/ssb-db2/pull/339, I had a `if (sizeDiff > 0) resetIndexes()` but this misses a corner case. `sizeDiff` is only greater than zero if truncation removed at least one block. But `sizeDiff === 0` can mean two very different things:

- Compaction found no holes at all, and the log does not need compaction, it's left intact
- Compaction found holes but only a few, and performed "shifting" of records to rewrite the log, but the total size remained the same

We need to rebuild indexes in the 2nd case, but not in the 1st. So we need a way of knowing the difference between these cases.

## Solution

Use `sizeDiff === 1` as a special case where no blocks have been truncated (the log size remained the same) but some holes have been filled, thus requiring ssb-db2 to rebuild indexes.

I think it's safe to say that sizeDiff is 1 byte because the minimum size of a block is 3 bytes because just the "End Of Block" marker takes 2 bytes.